### PR TITLE
Add a .config/appearance/current file

### DIFF
--- a/Appearance.xcodeproj/project.pbxproj
+++ b/Appearance.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		91AF305023DCC17000D394BA /* AppearanceUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91AF304F23DCC17000D394BA /* AppearanceUITests.swift */; };
 		91AFF5B925DB151900E1FBC5 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 91AFF5B825DB151900E1FBC5 /* LaunchAtLogin */; };
 		91C208F425CC4CA6002D021A /* FileManager+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C208F325CC4CA6002D021A /* FileManager+extension.swift */; };
+		91F0EE33262462D500B979FB /* LaunchUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91F0EE32262462D500B979FB /* LaunchUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +67,7 @@
 		91AF304F23DCC17000D394BA /* AppearanceUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceUITests.swift; sourceTree = "<group>"; };
 		91AF305123DCC17000D394BA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		91C208F325CC4CA6002D021A /* FileManager+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+extension.swift"; sourceTree = "<group>"; };
+		91F0EE32262462D500B979FB /* LaunchUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -174,6 +176,7 @@
 			isa = PBXGroup;
 			children = (
 				91AF304F23DCC17000D394BA /* AppearanceUITests.swift */,
+				91F0EE32262462D500B979FB /* LaunchUITests.swift */,
 				91AF305123DCC17000D394BA /* Info.plist */,
 			);
 			path = AppearanceUITests;
@@ -364,6 +367,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				91F0EE33262462D500B979FB /* LaunchUITests.swift in Sources */,
 				91AF305023DCC17000D394BA /* AppearanceUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Appearance/AppDelegate.swift
+++ b/Appearance/AppDelegate.swift
@@ -61,6 +61,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         hooksController.start()
 
         hooksController.add { [weak self] theme in
+            os_log("Will update current colorscheme file, colorscheme is %@",
+                   theme.colorScheme.description)
+            let filename = FileManager.default.currentColorschemeFile.absoluteURL
+            do {
+                try theme.colorScheme.description.write(to: filename, atomically: true, encoding: String.Encoding.utf8)
+            } catch {
+                os_log("error: %@", error.localizedDescription)
+                self?.alert(title: "Error updating current colorscheme file: \(filename)", body: error.localizedDescription)
+            }
+            os_log("Did update current colorscheme file")
+        }
+
+        hooksController.add { [weak self] theme in
             let enumerator = FileManager.default.enumerator(atPath: FileManager.default.hooksDirectory.relativePath)
             while let element = enumerator?.nextObject() as? String {
                 os_log("Iterating over file %@", element.debugDescription)

--- a/Appearance/AppDelegate.swift
+++ b/Appearance/AppDelegate.swift
@@ -58,7 +58,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         FileManager.default.prepareConfigDirectory()
 
         statusItem = makeStatusItem()
-        hooksController.start()
 
         hooksController.add { [weak self] theme in
             os_log("Will update current colorscheme file, colorscheme is %@",
@@ -101,6 +100,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             }
         }
+
+        hooksController.start()
+        hooksController.executeHooks()
     }
 
     func alert(title: String, body: String) {

--- a/Appearance/FileManager+extension.swift
+++ b/Appearance/FileManager+extension.swift
@@ -21,6 +21,10 @@ extension FileManager {
         return configDirectory.appendingPathComponent("hooks")
     }
 
+    var currentColorschemeFile: URL {
+        return configDirectory.appendingPathComponent("current")
+    }
+
     /// Prepares the file system for the application by creating needed files and directories
     func prepareConfigDirectory() {
         os_log("Will prepare config directory")

--- a/Appearance/FileManager+extension.swift
+++ b/Appearance/FileManager+extension.swift
@@ -12,9 +12,17 @@ import ShellOut
 
 extension FileManager {
     var configDirectory: URL {
-        return homeDirectoryForCurrentUser
-            .appendingPathComponent(".config")
-            .appendingPathComponent("appearance")
+        guard let path = ProcessInfo.processInfo.environment["APPEARANCE_CONFIG_PATH"] else {
+            return homeDirectoryForCurrentUser
+                .appendingPathComponent(".config")
+                .appendingPathComponent("appearance")
+        }
+
+        guard let url = URL(string: path) else {
+            fatalError("APPEARANCE_CONFIG_PATH didn't conform to valid URL")
+        }
+
+        return url
     }
 
     var hooksDirectory: URL {

--- a/Appearance/HooksController.swift
+++ b/Appearance/HooksController.swift
@@ -30,7 +30,7 @@ class HooksController {
         hooks.append(hook)
     }
 
-    private func executeHooks() {
+    func executeHooks() {
         os_log("Will execute hooks, colorscheme is %@", theme.colorScheme.description)
         for hook in hooks {
             hook(theme)

--- a/AppearanceTests/AppearanceTests.swift
+++ b/AppearanceTests/AppearanceTests.swift
@@ -17,16 +17,4 @@ class AppearanceTests: XCTestCase {
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-
-    func testExample() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
 }

--- a/AppearanceUITests/AppearanceUITests.swift
+++ b/AppearanceUITests/AppearanceUITests.swift
@@ -9,6 +9,21 @@
 import XCTest
 
 class AppearanceUITests: XCTestCase {
+
+    lazy var configPath: URL = {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    }()
+
+    lazy var launchEnvironment: [String : String] = {
+        ["APPEARANCE_CONFIG_PATH": configPath.absoluteString]
+    }()
+
+    lazy var app: XCUIApplication = {
+        let app = XCUIApplication()
+        app.launchEnvironment = launchEnvironment
+        return app
+    }()
+
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
 
@@ -20,23 +35,5 @@ class AppearanceUITests: XCTestCase {
 
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() {
-        // UI tests must launch the application that they test.
-        let app = XCUIApplication()
-        app.launch()
-
-        // Use recording to get started writing UI tests.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-    }
-
-    func testLaunchPerformance() {
-        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, *) {
-            // This measures how long it takes to launch your application.
-            measure(metrics: [XCTOSSignpostMetric.applicationLaunch]) {
-                XCUIApplication().launch()
-            }
-        }
     }
 }

--- a/AppearanceUITests/LaunchUITests.swift
+++ b/AppearanceUITests/LaunchUITests.swift
@@ -1,0 +1,41 @@
+//
+//  LaunchUITests.swift
+//  AppearanceUITests
+//
+//  Created by Alexander Ross on 2021-04-12.
+//  Copyright © 2021 Alexander Ross. All rights reserved.
+//
+
+import XCTest
+
+class LaunchUITests: AppearanceUITests {
+    func testLaunchPerformance() {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTOSSignpostMetric.applicationLaunch],
+                    block: app.launch)
+        }
+    }
+
+    func testCreatesHookDirectoryOnLaunch() {
+        app.launch()
+
+        let hooksPath = configPath
+            .appendingPathComponent("hooks", isDirectory: true)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: hooksPath.relativePath))
+    }
+
+    func testCurrentFileOnLaunchWhenDarkMode() throws {
+        let currentColorschemePath = configPath
+            .appendingPathComponent("current", isDirectory: false)
+        let currentColorScheme = UserDefaults
+            .standard
+            .string(forKey: "AppleInterfaceStyle") ?? "Light"
+
+        app.launch()
+        let content = try String(contentsOfFile: currentColorschemePath.relativePath, encoding: .utf8)
+
+        XCTAssertEqual(currentColorScheme, content)
+    }
+}


### PR DESCRIPTION
Containing Dark or Light. For example with Vim on startup it's faster to
read a file than to run the `defaults read` command.

Vimrc before:

```viml
if executable('defaults')
  if system('defaults read -g AppleInterfaceStyle') == "Dark\n"
    set background=dark
  else
    set background=light
  endif
else
  set background=dark
endif
```

Vimrc after:

```viml
if filereadable(expand("~/.config/appearance/current")) && match(readfile(expand("~/.config/appearance/current")), "Light") != -1
  set background=light
else
  set background=dark
endif
```

- [x] Tests
- [x] Refactor
- [x] Create `current` on startup as well, not just when colorscheme changes